### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,29 +7,29 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-callbackClickFunc   KEYWORD1
-callbackPressFunc   KEYWORD1
+callbackClickFunc	KEYWORD1
+callbackPressFunc	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setClickTime            KEYWORD2
-setPressTime            KEYWORD2
-setDebounceTime         KEYWORD2
-attachClick             KEYWORD2
-attachDoubleClick       KEYWORD2
-attachLongPressStart    KEYWORD2
-attachLongPressStop     KEYWORD2
-attachDuringLongPress   KEYWORD2
-isLongPressed           KEYWORD2
-loop                    KEYWORD2
+setClickTime	KEYWORD2
+setPressTime	KEYWORD2
+setDebounceTime	KEYWORD2
+attachClick	KEYWORD2
+attachDoubleClick	KEYWORD2
+attachLongPressStart	KEYWORD2
+attachLongPressStop	KEYWORD2
+attachDuringLongPress	KEYWORD2
+isLongPressed	KEYWORD2
+loop	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-OneButton   KEYWORD2
+OneButton	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords